### PR TITLE
update regex allowed versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ itertools = "0.4.0"
 lazy_static = "0.1.14"
 strcursor = "0.2.3"
 
-regex = { version = "0.1.56, <=0.1.65", optional = true }
+regex = { version = "0.1.56", optional = true }
 unicode-normalization = { version = "0.1.2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
regex v0.1.66 has been yanked, and semver compatibility restored, so I think this shouldn't break anything, and allows compatibility with crates requiring more recent versions of regex